### PR TITLE
Chore: fix b2500d card overflow

### DIFF
--- a/b2500d-card.js
+++ b/b2500d-card.js
@@ -122,7 +122,7 @@ class B2500DCard extends LitElement {
 
       .grid {
         display:grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         gap:14px;
       }
 
@@ -143,6 +143,7 @@ class B2500DCard extends LitElement {
           border-radius: var(--radius);
           padding:12px;
           box-sizing:border-box;
+          min-width: 0;
         }
         
         .icon {
@@ -176,6 +177,7 @@ class B2500DCard extends LitElement {
         color:var(--text);
         font-size: var(--ha-font-size-l);
         margin-bottom: 10px;
+        min-width: 0;
       }
 
       .right-big {
@@ -183,6 +185,7 @@ class B2500DCard extends LitElement {
         font-weight:400; 
         font-size:24px; 
         color:var(--text);
+        white-space: nowrap;
       }
 
       .big-num{ font-size:24px; color:var(--text); font-weight:400; }
@@ -228,8 +231,10 @@ class B2500DCard extends LitElement {
 
         .ring {
           position: relative; 
-          width:150px;
-          height:150px;
+          width:min(150px, 100%);
+          aspect-ratio:1 / 1;
+          height:auto;
+          flex:0 0 auto;
           border-radius:50%;
           display:grid;
           place-items:center;
@@ -267,9 +272,14 @@ class B2500DCard extends LitElement {
         }
         
         .pulse-green {
+          position:absolute;
+          top:8px;
+          left:50%;
+          translate:-50% 0;
           color: #5be5bf;
-          scale: 0.8;
+          scale: 0.7;
           animation: pulseGreen 2.5s infinite ease-in-out;
+          pointer-events:none;
         }
 
      .kwh{ font-size:28px; font-weight:400; color: white; }
@@ -283,18 +293,41 @@ class B2500DCard extends LitElement {
       }
 
       .row{
-        display:flex; align-items:center; justify-content:space-between; gap:10px;
+        display:grid; grid-template-columns:minmax(0, 1fr) auto; align-items:center; gap:10px;
         padding:18px; 
       }
-      .row .left{ display:flex; align-items:center; gap:12px; }
-      .row .right{ color:var(--muted); font-weight:600; display:flex; align-items:center; }
+      .row .left{ display:flex; align-items:center; gap:12px; min-width:0; }
+      .row .left span,
+      .row .left div{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+      .row .right{ color:var(--muted); font-weight:600; display:flex; align-items:center; justify-content:flex-end; min-width:0; }
       .chev{ width:10px; height:10px; border-right:2px solid var(--muted); border-top:2px solid var(--muted); transform:rotate(45deg); margin-left:6px; }
 
       .divider{ height:1px; background:var(--divider); margin:1px 0 0; }
 
-      .row .right ha-select,
-      .row .right ha-switch {
+      .row .right ha-select {
         min-width: 140px;
+        max-width: 100%;
+      }
+
+      .row .right ha-select {
+        width: min(220px, 100%);
+      }
+
+      .row .right ha-switch {
+        flex:0 0 auto;
+      }
+
+      .row:has(ha-select) {
+        grid-template-columns:1fr;
+      }
+
+      .row:has(ha-select) .right {
+        justify-content:stretch;
+      }
+
+      .row:has(ha-select) .right ha-select {
+        width:100%;
+        max-width:100%;
       }
 
       @media(max-width:700px){
@@ -689,12 +722,7 @@ class B2500DCard extends LitElement {
                           ${solar > output && this._batteryPercent < 100 ? html`
                             <ha-icon 
                               icon="mdi:lightning-bolt" 
-                              class="pulse-green" 
-                              style="
-                                position:absolute; 
-                                top:10px; 
-                                transform: translateX(-50%); 
-                              ">
+                              class="pulse-green">
                             </ha-icon>
                           ` : ''}
                         


### PR DESCRIPTION
## Summary

Fixes narrow Lovelace column rendering at desktop zoom by allowing grid/flex children to shrink within the card, keeping the battery ring circular, and preventing settings controls from overlapping their labels.

## Before / after

| Case | Before | After |
| --- | --- | --- |
| Desktop Chrome default zoom in a narrow Lovelace column | content spilled outside the card edge | card content stays inside the card |
| Battery gauge after shrinking the grid column | ring could become distorted when the column was squeezed | ring uses a responsive square aspect ratio and remains circular |
| Custom settings with long German labels, e.g. `Überschusseinspeisung` | switch could overlap the label | switch stays fixed at the right; label ellipsizes instead of overlapping |
| Charging bolt icon | inline top/transform positioning could overlap the kWh text at default zoom | bolt placement is handled by CSS and sits above the value |

This was tested against a real HACS install of `Neisi/b2500d-card` v1.7.1 with custom settings for `Modus`, `Überschusseinspeisung`, and `Temperatur`.

## Validation

- `node --check b2500d-card.js`
- `npm run build` passes after installing dev dependencies; Rollup keeps the remote `lit-element` URL as an external dependency, matching the existing source import.
