### PR TITLE
Chore: 24 bug custom_settings entities ignore home assistant display precision and esphome accuracy_decimals

### DIFF
--- a/dist/b2500d-card.js
+++ b/dist/b2500d-card.js
@@ -870,6 +870,17 @@ class B2500DCard extends i {
     return formatted;
   }
 
+  _formatEntityValue(entity) {
+    const formatted = this._hass.formatEntityState(entity);
+    const unit = entity.attributes.unit_of_measurement;
+
+    if (!unit) return formatted;
+
+    return formatted.endsWith(unit)
+      ? formatted.slice(0, -unit.length).trim()
+      : formatted;
+  }
+
 
 
 //RENDER COMPACT
@@ -1121,7 +1132,7 @@ class B2500DCard extends i {
                   ${icon ? b`<ha-icon icon="${icon}"></ha-icon>` : ""}
                   <div style="font-weight:600">${name}</div>
                 </div>
-                <div class="flex-wrapper"><div class="big-num">${entity.state}</div> <div class="big-num-unit">${entity.attributes.unit_of_measurement}</div></div>
+                <div class="flex-wrapper"><div class="big-num">${this._formatEntityValue(entity)}</div> <div class="big-num-unit">${entity.attributes.unit_of_measurement}</div></div>
               </div>
               ${renderDivider}
             `;}

--- a/src/b2500d-card.js
+++ b/src/b2500d-card.js
@@ -587,6 +587,17 @@ class B2500DCard extends LitElement {
     return formatted;
   }
 
+  _formatEntityValue(entity) {
+    const formatted = this._hass.formatEntityState(entity);
+    const unit = entity.attributes.unit_of_measurement;
+
+    if (!unit) return formatted;
+
+    return formatted.endsWith(unit)
+      ? formatted.slice(0, -unit.length).trim()
+      : formatted;
+  }
+
 
 
 //RENDER COMPACT
@@ -838,7 +849,7 @@ class B2500DCard extends LitElement {
                   ${icon ? html`<ha-icon icon="${icon}"></ha-icon>` : ""}
                   <div style="font-weight:600">${name}</div>
                 </div>
-                <div class="flex-wrapper"><div class="big-num">${entity.state}</div> <div class="big-num-unit">${entity.attributes.unit_of_measurement}</div></div>
+                <div class="flex-wrapper"><div class="big-num">${this._formatEntityValue(entity)}</div> <div class="big-num-unit">${entity.attributes.unit_of_measurement}</div></div>
               </div>
               ${renderDivider}
             `;}


### PR DESCRIPTION
## ✨ Description
uses the HA display precision in custom settings sensor values

## 🐞 Ticket / Issue
#24 

## 🔍 Motivation
avoiding raw floating-point values (e.g., 220.123456) 

## 🚨 Breaking Changes
- [ ] Yes
- [x] No
